### PR TITLE
Modified Advantage Person Profile Page

### DIFF
--- a/RockWeb/Themes/Rock/Layouts/LCBCAdvantagePersonProfileHome.aspx
+++ b/RockWeb/Themes/Rock/Layouts/LCBCAdvantagePersonProfileHome.aspx
@@ -1,0 +1,65 @@
+﻿<%@ Page Language="C#" MasterPageFile="Site.Master" AutoEventWireup="true" Inherits="Rock.Web.UI.RockPage" %>
+
+<%@ MasterType TypeName="Rock.Web.UI.RockMasterPage" %>
+<script runat="server">
+
+    protected override void OnLoad( EventArgs e )
+    {
+        base.OnLoad( e );
+        Master.ShowPageTitle = false;
+    }
+
+</script>
+
+<asp:Content ID="ctMain" ContentPlaceHolderID="main" runat="server">
+
+    <div class="profile-content position-relative">
+        <div id="profilenavigation" class="profile-sticky-nav">
+            <div class="profile-sticky-nav-placeholder"></div>
+            <div class="profile-nav">
+                <Rock:Zone Name="Profile Navigation Left" CssClass="flex-1 z-10" runat="server" />
+                <Rock:Zone Name="Profile Navigation" CssClass="zone-nav" runat="server" />
+                <Rock:Zone Name="Profile Navigation Right" CssClass="d-flex flex-1 justify-content-end overflow-hidden" runat="server" />
+            </div>
+        </div>
+
+        <!-- Ajax Error -->
+        <div class="alert alert-danger ajax-error no-index" style="display:none">
+            <p><strong>Error</strong></p>
+            <span class="ajax-error-message"></span>
+        </div>
+        <div class="person-profile person-profile-row">
+
+
+            <Rock:Zone Name="Profile" CssClass="profile-main profile-sidebar" runat="server" />
+
+            <div class="profile-data">
+                <Rock:Zone Name="Badge Bar" CssClass="zone-badgebar" runat="server" />
+
+                <div class="person-profile-row">
+                    <Rock:Zone Name="Section A1" CssClass="profile-notes" runat="server" />
+                    <Rock:Zone Name="Section A2" CssClass="profile-sidebar" runat="server" />
+                </div>
+
+                <Rock:Zone Name="Section A3" runat="server" />
+            </div>
+        </div>
+
+        <div class="person-profile-ext">
+
+            <div class="row">
+                <div class="col-md-12">
+                    <Rock:Zone Name="Section C1" runat="server" />
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-4">
+                    <Rock:Zone Name="Section D1" runat="server" />
+                </div>
+                <div class="col-md-8">
+                    <Rock:Zone Name="Section D2" runat="server" />
+                </div>
+            </div>
+        </div>
+	</div>
+</asp:Content>


### PR DESCRIPTION
This page is a modified version or the person profile page. It's designed to support the needs of the Church Relations/Advantage pages in Rock. 

<hr>

**Context from Triumph**

Why this is necessary:

This layout is an exact duplicate of the PersonProfileHome.aspx file (github link) that’s already in that directory – the only reason we need it is because there are blocks installed on the core Person Profile Home layout that we don’t want to have also show up on the advantage person profile page.

In core this layout is only used on a single page and so the blocks could, in theory, be moved to only be added to the single page. That would have allowed us to use the core layout for the Advantage profile page. But on evaluation, that seems like a bigger edit to core’s design and since your team has added another page that uses that layout (and therefore gets those blocks), we didn’t want to add the technical debt of your having to keep those pages in sync with their blocks.

So instead we copied the core layout to a different name, and we’re using that layout for your Advantage project so its blocks are independent of the regular person profile layout. If the core PersonProfileHome page is ever updated in core, this cloned layout should be updated to match.
