### PR TITLE
SMS OptOut Message Update

### DIFF
--- a/Rock/Model/Communication/SmsAction/SmsActionService.cs
+++ b/Rock/Model/Communication/SmsAction/SmsActionService.cs
@@ -367,7 +367,7 @@ namespace Rock.Model
                     {
                         ToNumber = cleanedNumber,
                         FromNumber = message.ToNumber,
-                        Message = "You have opted out of messages."
+                        Message = "You have been unsubscribed from LCBC Updates & Alerts. No more messages will be sent. Reply HELP for help."
                     }
                 }
             };


### PR DESCRIPTION
We are updating a hardcoded message that is sent when someone opts out of SMS using Stop and other keywords. Rock is brining a new feature in v18 where this can be set in the UI.